### PR TITLE
Improve Date Search

### DIFF
--- a/Sources/Logbook/Logbook.swift
+++ b/Sources/Logbook/Logbook.swift
@@ -239,55 +239,81 @@ extension Logbook {
         eventsByID[id]
     }
     
-    /// Retrieves the events within the specified interval.
-    /// 
-    /// - Complexity: O(log(n)).
-    /// 
-    /// - Parameters:
-    ///   - start: the date from which to retrieve events
-    ///   - end: the date up and including which to retrieve events
-    /// 
-    /// - Returns: An `Array` of matching events.
-    public func events(
-        onOrAfter start: Date = .distantPast,
-        onOrBefore end: Date = .distantFuture
-    ) async throws -> [Event] {
-        var matchingEvents: [Event] = []
-        for try await event in self {
-            if event.date < start {
+    /// Returns all events in the provided range.
+    public subscript(range: Range<Date>) -> [Event] {
+        var matchingEvents = [Event]()
+        for (date, eventIDs) in eventIDsByDate {
+            if date < range.lowerBound {
                 continue
-            } else if event.date >= start && event.date <= end {
-                matchingEvents.append(event)
+            } else if range.contains(date) {
+                matchingEvents.append(contentsOf: eventIDs.compactMap { eventsByID[$0] })
             } else {
-                break 
+                break
             }
         }
         return matchingEvents
     }
 
-    /// Retrieves the events within the specified interval.
-    /// 
-    /// - Complexity: O(log(n)).
-    /// 
-    /// - Parameters:
-    ///   - start: the date after which to retrieve events
-    ///   - end: the date up to which to retrieve events
-    /// 
-    /// - Returns: An `Array` of matching events.
-    public func events(
-        after start: Date = .distantPast, 
-        before end: Date = .distantFuture
-    ) async throws -> [Event] {
-        var matchingEvents: [Event] = []
-        for try await event in self {
-            if event.date < start {
+    /// Returns all events in the provided range.
+    public subscript(range: ClosedRange<Date>) -> [Event] {
+        var matchingEvents = [Event]()
+        for (date, eventIDs) in eventIDsByDate {
+            if date < range.lowerBound {
                 continue
-            } else if event.date > start && event.date < end {
-                matchingEvents.append(event)
+            } else if range.contains(date) {
+                matchingEvents.append(contentsOf: eventIDs.compactMap { eventsByID[$0] })
             } else {
-                break 
+                break
             }
         }
         return matchingEvents
+    }
+
+    /// Returns all events in the provided range.
+    public subscript(range: PartialRangeFrom<Date>) -> [Event] {
+        var matchingEvents = [Event]()
+        for (date, eventIDs) in eventIDsByDate {
+            if date < range.lowerBound {
+                continue
+            } else {
+                matchingEvents.append(contentsOf: eventIDs.compactMap { eventsByID[$0] })
+            }
+        }
+        return matchingEvents
+    }
+
+    /// Returns all events in the provided range.
+    public subscript(range: PartialRangeUpTo<Date>) -> [Event] {
+        var matchingEvents = [Event]()
+        for (date, eventIDs) in eventIDsByDate {
+            if date < range.upperBound {
+                matchingEvents.append(contentsOf: eventIDs.compactMap { eventsByID[$0] })
+            } else {
+                break
+            }
+        }
+        return matchingEvents
+    }
+
+    /// Returns all events in the provided range.
+    public subscript(range: PartialRangeThrough<Date>) -> [Event] {
+        var matchingEvents = [Event]()
+        for (date, eventIDs) in eventIDsByDate {
+            if date <= range.upperBound {
+                matchingEvents.append(contentsOf: eventIDs.compactMap { eventsByID[$0] })
+            } else {
+                break
+            }
+        }
+        return matchingEvents
+    }
+
+    /// Returns all events in the provided range.
+    public subscript(range: UnboundedRange) -> [Event] {
+        eventIDsByDate.flatMap { (_, eventIDs) in
+            eventIDs.compactMap { eventID in 
+                eventsByID[eventID]
+            }
+        }
     }
 }

--- a/Tests/LogbookTests/LogbookTests.swift
+++ b/Tests/LogbookTests/LogbookTests.swift
@@ -168,9 +168,7 @@ final class LogbookTests: XCTestCase {
         XCTAssertNil(existingEvent)
         let retrievedEvent = await logbook.event(withID: event.id)
         XCTAssertEqual(event, retrievedEvent)
-        let dateRetrievedEvents = try await logbook.events(
-            onOrAfter: event.date, 
-            onOrBefore: event.date)
+        let dateRetrievedEvents = await logbook[event.date...event.date]
         XCTAssertEqual(dateRetrievedEvents.first, event)
     }
 
@@ -187,9 +185,9 @@ final class LogbookTests: XCTestCase {
         XCTAssertEqual(originalEvent, replacedEvent)
         let retrievedEvent = await logbook.event(withID: originalEvent.id)
         XCTAssertEqual(updatedEvent, retrievedEvent)
-        let correctDateRetrievedEvents = try await logbook.events(onOrAfter: newDate)
+        let correctDateRetrievedEvents = await logbook[newDate...]
         XCTAssertEqual(correctDateRetrievedEvents.first, updatedEvent)
-        let incorrectDateRetrievedEvents = try await logbook.events(before: newDate)
+        let incorrectDateRetrievedEvents = await logbook[..<newDate]
         XCTAssertTrue(incorrectDateRetrievedEvents.isEmpty)
     }
 
@@ -203,9 +201,7 @@ final class LogbookTests: XCTestCase {
         XCTAssertEqual(originalEvent, replacedEvent)
         let retrievedEvent = await logbook.event(withID: originalEvent.id)
         XCTAssertEqual(updatedEvent, retrievedEvent)
-        let dateRetrievedEvents = try await logbook.events(
-            onOrAfter: originalEvent.date,
-            onOrBefore: originalEvent.date)
+        let dateRetrievedEvents = await logbook[originalEvent.date...originalEvent.date]
         XCTAssertEqual(dateRetrievedEvents.first, updatedEvent)
     }
     
@@ -229,9 +225,7 @@ final class LogbookTests: XCTestCase {
         ]
         let logbook = Logbook(location: FilePath("/dev/null"), events: events)
         let searchInterval = DateInterval(start: Date(timeIntervalSince1970: 0), duration: 2)
-        let retrievedEvents = try await logbook.events(
-            onOrAfter: searchInterval.start,
-            onOrBefore: searchInterval.end)
+        let retrievedEvents = await logbook[searchInterval.start...searchInterval.end]
         XCTAssertEqual(Array(events[0...2]), retrievedEvents)
     }
 }


### PR DESCRIPTION
### Objectives

This pull request improves the `Event` date search API to use range subscripts, to make it feel like logbooks are date-indexed.

### Design

Callers can subscript using:
* `Range`
* `ClosedRange`
* `PartialRangeUpTo`
* `PartialRangeThrough`
* `UnboundRange`

Each of these subscripts return an array of events.

### Implementation

Each method follows the same pattern of iterating over the `eventIDsByDate` dictionary, and stopping the loop when the last date of the range is found. This means these subscripts have worst-case O(n) complexity, and best-case O(log(n)) complexity.