### PR TITLE
Support Event Search By Experience

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-standard-platforms:
     strategy:
+      fail-fast: false
       matrix:
         platform:
         - ubuntu-latest
@@ -30,6 +31,7 @@ jobs:
   test-mobile-platforms:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         destination:
         - "platform=iOS Simulator,name=iPhone 12,OS=15.2"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 .DS_Store
-/.build
-/Packages
-/*.xcodeproj
-xcuserdata/
-DerivedData/
-.swiftpm/config/registries.json
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
-.netrc
+.build
+.swiftpm
+Package.resolved

--- a/Sources/Logbook/Logbook.swift
+++ b/Sources/Logbook/Logbook.swift
@@ -316,4 +316,17 @@ extension Logbook {
             }
         }
     }
+
+    // MARK: Experience Search
+
+    /// Returns all events with the specified experience.
+    /// 
+    /// - Parameter experience: the name of the experience to search for
+    /// 
+    /// - Returns: All events with the specified experience listed.
+    public func events(withExperience experience: String) -> [Event] {
+        eventsByID.values.filter { event in 
+            event.experience[experience] != nil
+        }
+    }
 }

--- a/Tests/LogbookTests/LogbookTests.swift
+++ b/Tests/LogbookTests/LogbookTests.swift
@@ -252,11 +252,11 @@ final class LogbookTests: XCTestCase {
         ]
         let logbook = Logbook(location: testFilePath, events: events)
         let eventsWithPIC = await logbook.events(withExperience: "PIC")
-        XCTAssertEqual(eventsWithPIC, Array(events[0...1]))
+        XCTAssertEqual(Set(eventsWithPIC), Set(events[0...1]))
         let eventsWithSIC = await logbook.events(withExperience: "SIC")
-        XCTAssertEqual(eventsWithSIC, [events[1]])
+        XCTAssertEqual(Set(eventsWithSIC), Set([events[1]]))
         let eventsWithLandings = await logbook.events(withExperience: "Landings")
-        XCTAssertEqual(eventsWithLandings, [events[2]])
+        XCTAssertEqual(Set(eventsWithLandings), ([events[2]]))
         let eventsWithUnnamedExperience = await logbook.events(withExperience: "")
         XCTAssertTrue(eventsWithUnnamedExperience.isEmpty)
     }
@@ -274,10 +274,10 @@ final class LogbookTests: XCTestCase {
         let oldEventsWithPIC = await logbook.events(
             withExperience: "Total", 
             within: refDate...refDate)
-        XCTAssertEqual(oldEventsWithPIC, [events[0]])
+        XCTAssertEqual(Set(oldEventsWithPIC), [events[0]])
         let allEventsWithPIC = await logbook.events(
             withExperience: "Total", 
             within: refDate...)
-        XCTAssertEqual(allEventsWithPIC, Array(events[0...1]))
+        XCTAssertEqual(Set(allEventsWithPIC), Set(events[0...1]))
     }
 }

--- a/Tests/LogbookTests/LogbookTests.swift
+++ b/Tests/LogbookTests/LogbookTests.swift
@@ -244,10 +244,11 @@ final class LogbookTests: XCTestCase {
 
     /// Asserts requesting all events with the specified experience key yields expected events.
     func testExperienceSearch() async {
+        let date = Date()
         let events = [
-            Event(experience: ["PIC": .time(3600)]),
-            Event(experience: ["PIC": .time(4800), "SIC": .time(4800)]),
-            Event(experience: ["Landings": .count(1)]),
+            Event(date: date, experience: ["PIC": .time(3600)]),
+            Event(date: date, experience: ["PIC": .time(4800), "SIC": .time(4800)]),
+            Event(date: date, experience: ["Landings": .count(1)]),
         ]
         let logbook = Logbook(location: testFilePath, events: events)
         let eventsWithPIC = await logbook.events(withExperience: "PIC")

--- a/Tests/LogbookTests/LogbookTests.swift
+++ b/Tests/LogbookTests/LogbookTests.swift
@@ -244,4 +244,22 @@ final class LogbookTests: XCTestCase {
         let unboundRangeEvents = await logbook[...]
         XCTAssertEqual(events, unboundRangeEvents)
     }
+
+    /// Asserts requesting all events with the specified experience key yields expected events.
+    func testExperienceSearch() async throws {
+        let events = [
+            Event(experience: ["PIC": .time(3600)]),
+            Event(experience: ["PIC": .time(4800), "SIC": .time(4800)]),
+            Event(experience: ["Landings": .count(1)]),
+        ]
+        let logbook = Logbook(location: testFilePath, events: events)
+        let eventsWithPIC = await logbook.events(withExperience: "PIC")
+        XCTAssertEqual(eventsWithPIC, Array(events[0...1]))
+        let eventsWithSIC = await logbook.events(withExperience: "SIC")
+        XCTAssertEqual(eventsWithSIC, [events[1]])
+        let eventsWithLandings = await logbook.events(withExperience: "Landings")
+        XCTAssertEqual(eventsWithLandings, [events[2]])
+        let eventsWithUnnamedExperience = await logbook.events(withExperience: "")
+        XCTAssertTrue(eventsWithUnnamedExperience.isEmpty)
+    }
 }

--- a/Tests/LogbookTests/LogbookTests.swift
+++ b/Tests/LogbookTests/LogbookTests.swift
@@ -240,13 +240,10 @@ final class LogbookTests: XCTestCase {
         // PartialRangeThrough
         let partialRangeThroughEvents = await logbook[...date2]
         XCTAssertEqual(Array(events[...2]), partialRangeThroughEvents)
-        // UnboundRange
-        let unboundRangeEvents = await logbook[...]
-        XCTAssertEqual(events, unboundRangeEvents)
     }
 
     /// Asserts requesting all events with the specified experience key yields expected events.
-    func testExperienceSearch() async throws {
+    func testExperienceSearch() async {
         let events = [
             Event(experience: ["PIC": .time(3600)]),
             Event(experience: ["PIC": .time(4800), "SIC": .time(4800)]),
@@ -261,5 +258,25 @@ final class LogbookTests: XCTestCase {
         XCTAssertEqual(eventsWithLandings, [events[2]])
         let eventsWithUnnamedExperience = await logbook.events(withExperience: "")
         XCTAssertTrue(eventsWithUnnamedExperience.isEmpty)
+    }
+
+    /// Asserts requesting events with a specific experience key within a provided
+    /// date range returns the expected events.
+    func testDateAndExperienceSearch() async {
+        let refDate = Date(timeIntervalSinceReferenceDate: 0)
+        let events = [
+            Event(date: refDate, experience: ["Total": .time(4000)]),
+            Event(date: refDate + 1, experience: ["Total": .time(1000)]),
+            Event(date: refDate + 1, experience: [:]),
+        ]
+        let logbook = Logbook(location: testFilePath, events: events)
+        let oldEventsWithPIC = await logbook.events(
+            withExperience: "Total", 
+            within: refDate...refDate)
+        XCTAssertEqual(oldEventsWithPIC, [events[0]])
+        let allEventsWithPIC = await logbook.events(
+            withExperience: "Total", 
+            within: refDate...)
+        XCTAssertEqual(allEventsWithPIC, Array(events[0...1]))
     }
 }


### PR DESCRIPTION
### Objectives

This pull request adds support for event search by experience type, and optionally by both experience type and date. This closes #3.

### Design

Two new methods are available:
```swift
/// Returns all events with the specified experience.
/// 
/// - Complexity: O(n).
/// 
/// - Parameter experience: the name of the experience to search for
/// 
/// - Returns: All events with the specified experience listed.
public func events(withExperience experience: String) async -> [Event]
```
```swift
/// Returns all events with the specified experience within the provided date range.
/// 
/// - Complexity: O(log(n))
/// 
/// - Parameter experience: the name of the experience to search for
/// - Parameter dateRange: the date range within which to search
/// 
/// - Returns: All events with the specified experience within the provided date range.
public func events<R: RangeExpression>(withExperience experience: String, within dates: R) -> [Event] where R.Bound == Date
```

### Implementation

Both methods are implemented through simple iteration. In the case of the date-constrained search method, it declared O(log(n)) complexity by first searching the date index, then mapping those results to the events themselves. Worst-case complexity is the same.
